### PR TITLE
fix: add @typescript-eslint plugins

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,6 @@
 {
   "extends": ["airbnb", "airbnb/hooks", "react-app", "prettier"],
+  "plugins": ["@typescript-eslint"],
   "env": {
     "browser": true,
     "jasmine": true,


### PR DESCRIPTION
`.eslintrc.json`에서 `@typescript-eslint`를 `plugins`에 추가해 주지 않아 에러가 생겨 추가해 주었습니다.  